### PR TITLE
Fixes/update intellij version to 2020.3

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="corretto-11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
   <component name="idea.plugin.psiviewer.controller.project.PsiViewerProjectService">

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 A plugin that adds RON (Rusty Object Notation) support to IntelliJ IDEA
 
 ## Versions
+1.4 - Updated to support 2020.3 edition of Intellij IDEs
+
 1.3 - Adds support for block comments and cleaned up some code
 
 1.2 - Adds context menu option for creating RON files

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'org.jonahhenriksson'
-version '1.3'
+version '1.4'
 
 sourceSets.main.java.srcDirs 'src/main/gen'
 
@@ -17,10 +17,10 @@ dependencies {
 }
 
 intellij {
-    version '2020.2'
+    version '2020.3'
 }
 patchPluginXml {
-    changeNotes """Added support for block comments and cleaned up some code"""
+    changeNotes """Updated to support 2020.3 edition of Intellij IDEs"""
 }
 
 publishPlugin {


### PR DESCRIPTION
This seem to be enough to make plugin work on 2020.3

Fixes #3 

To be able to build the plugin you should now use corretto-11.
More on this here: https://blog.jetbrains.com/platform/2020/09/intellij-project-migrates-to-java-11/

In my case I needed to download version for mac and couldn't find it on official downloading page, but I found it here https://github.com/corretto/corretto-11/releases

With best regards, Vitaly